### PR TITLE
Fix HACS release metadata and add model-aware Jackery controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,19 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
 [![maintainer](https://img.shields.io/badge/maintainer-%40theak-blue.svg)](https://github.com/theak)
-[![version](https://img.shields.io/badge/version-1.0.2-blue.svg)](https://github.com/theak/jackery-homeassistant)
+[![version](https://img.shields.io/badge/version-1.1.0-blue.svg)](https://github.com/theak/jackery-homeassistant)
 
-Custom Home Assistant integration for monitoring Jackery portable power stations. This integration provides real-time sensor data for your Jackery devices including battery status, power output, temperature, and more.
+Custom Home Assistant integration for monitoring and controlling Jackery portable power stations. This integration provides real-time sensor data plus model-aware control entities for supported Jackery devices.
 
 ## Features
 
 - 🔋 **Battery Monitoring**: Track remaining battery percentage and temperature
 - ⚡ **Power Monitoring**: Monitor input/output power in watts
 - ⏱️ **Time Tracking**: View time to full charge and remaining output time
-- 🔌 **Output Status**: Binary sensors for AC, DC car, and USB output status
+- 🔌 **Output Control**: Switches for supported AC, DC, USB, and car outputs
+- ⚙️ **Device Controls**: Select and number entities for light mode, charge speed, battery protection, screen timeout, and more
+- 🧠 **Model-Aware Entities**: Only shows entities that the specific Jackery model actually reports
+- 📡 **MQTT Control Path**: Uses Jackery's device control channel for supported writable settings
 
 ## Supported Sensors
 
@@ -26,21 +29,26 @@ Custom Home Assistant integration for monitoring Jackery portable power stations
 | Output Power          | Current power output          | W        |
 | Input Power           | Current power input           | W        |
 | AC Input Power        | AC power input                | W        |
+| Car Input Power       | Car charging input            | W        |
 | Time to Full          | Estimated time to full charge | hours    |
 | Remaining Output Time | Estimated remaining runtime   | hours    |
 | AC Output Voltage     | AC output voltage             | V        |
+| AC Output Frequency   | AC output frequency           | Hz       |
+| Error Code            | Device error code             | n/a      |
 | Last Updated          | Timestamp of last data update | ISO 8601 |
 
-### Binary Sensors (ON/OFF)
+### Switches and Status
 
-| Sensor        | Description               |
-| ------------- | ------------------------- |
-| AC Output     | AC output status          |
-| DC Output     | DC output status          |
-| DC Car Output | DC car port output status |
-| USB Output    | USB output status         |
+Supported models expose different combinations of controllable entities. Examples include:
 
-**Note:** Different Jackery device models may report different combinations of DC output sensors. Early exploration suggests some models use a combined `odc` parameter while others use separate `odcc` and `odcu` parameters.
+| Entity Type | Examples |
+| ----------- | -------- |
+| Switches | AC Output, DC Output, USB Output, DC Car Output, Super Fast Charge, UPS Mode |
+| Selects | Light Mode, Charge Speed, Battery Protection |
+| Numbers | Auto Shutdown, Energy Saving, Screen Timeout |
+| Binary Sensors | Temperature Alarm, Power Alarm, Wireless Charging |
+
+**Note:** Different Jackery device models report different property sets. For example, some units expose a combined `odc` DC switch while others expose separate `odcc` and `odcu` switches for car and USB outputs. Unsupported controls are not created for devices that do not report those properties.
 
 ## Installation
 
@@ -49,7 +57,7 @@ Custom Home Assistant integration for monitoring Jackery portable power stations
 1. Make sure you have [HACS](https://hacs.xyz/) installed
 2. Add this repository as a custom repository in HACS
 3. Search for "Jackery" in the integrations section
-4. Install version `1.0.2` or newer and restart Home Assistant
+4. Install version `1.1.0` or newer and restart Home Assistant to load the integration code
 
 ### Option 2: Manual Installation
 
@@ -74,7 +82,7 @@ The integration will automatically discover your Jackery devices and create sens
 Once configured, you'll find your Jackery devices and their sensors in:
 
 - **Settings** → **Devices & Services** → **Entities**
-- Each device will have its own set of sensors
+- Each device will have its own set of supported sensors, switches, selects, and number entities
 
 You can use these sensors in:
 
@@ -101,7 +109,7 @@ automation:
   - alias: "Jackery AC Output On"
     trigger:
       platform: state
-      entity_id: binary_sensor.jackery_device_ac_output
+      entity_id: switch.jackery_device_ac_output
       to: "on"
     action:
       - service: notify.mobile_app
@@ -118,7 +126,7 @@ automation:
    - Ensure your account is active and not locked
 
 2. **HACS rejects version 1.0.1**
-   - Install version `1.0.2` or newer
+   - Install version `1.1.0` or newer
    - Version `1.0.1` was tagged before `hacs.json` was moved to the repository root, which newer HACS versions require
 
 3. **No Devices Found**
@@ -128,6 +136,10 @@ automation:
 4. **Sensors Not Updating**
    - Check the Home Assistant logs for errors
    - Verify your device has internet connectivity
+
+5. **Entities missing or extra entities are still shown after upgrading**
+   - Reload the Jackery config entry or restart Home Assistant after upgrading
+   - The integration creates entities based on the live property set reported by each device model
 
 ### Logs
 
@@ -149,6 +161,7 @@ logger:
 
 - `requests>=2.31.0`
 - `pycryptodomex>=3.19.0`
+- `socketry>=0.2.3`
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
 [![maintainer](https://img.shields.io/badge/maintainer-%40theak-blue.svg)](https://github.com/theak)
-[![version](https://img.shields.io/badge/version-1.0.1-blue.svg)](https://github.com/theak/jackery-homeassistant)
+[![version](https://img.shields.io/badge/version-1.0.2-blue.svg)](https://github.com/theak/jackery-homeassistant)
 
 Custom Home Assistant integration for monitoring Jackery portable power stations. This integration provides real-time sensor data for your Jackery devices including battery status, power output, temperature, and more.
 
@@ -49,7 +49,7 @@ Custom Home Assistant integration for monitoring Jackery portable power stations
 1. Make sure you have [HACS](https://hacs.xyz/) installed
 2. Add this repository as a custom repository in HACS
 3. Search for "Jackery" in the integrations section
-4. Click "Download" and restart Home Assistant
+4. Install version `1.0.2` or newer and restart Home Assistant
 
 ### Option 2: Manual Installation
 
@@ -117,11 +117,15 @@ automation:
    - Verify your Jackery account credentials
    - Ensure your account is active and not locked
 
-2. **No Devices Found**
+2. **HACS rejects version 1.0.1**
+   - Install version `1.0.2` or newer
+   - Version `1.0.1` was tagged before `hacs.json` was moved to the repository root, which newer HACS versions require
+
+3. **No Devices Found**
    - Make sure your Jackery device is connected to the internet
    - Verify the device is registered to your account
 
-3. **Sensors Not Updating**
+4. **Sensors Not Updating**
    - Check the Home Assistant logs for errors
    - Verify your device has internet connectivity
 

--- a/custom_components/jackery/__init__.py
+++ b/custom_components/jackery/__init__.py
@@ -9,6 +9,8 @@ import async_timeout
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
     UpdateFailed,
@@ -17,8 +19,15 @@ from homeassistant.util import dt as dt_util
 
 from .api import JackeryAPI, JackeryAuthenticationError
 from .const import DOMAIN, POLLING_INTERVAL_SEC
+from .features import expected_entity_domain_for_key, expected_unique_ids
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR]
+PLATFORMS: list[Platform] = [
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+    Platform.SWITCH,
+    Platform.SELECT,
+    Platform.NUMBER,
+]
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -53,9 +62,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return False
 
     coordinators = {}
+    expected_ids: set[str] = set()
+    device_registry = dr.async_get(hass)
     for device in devices:
         device_id = device["devId"]
         device_name = device.get("devName", f"Jackery Device {device_id}")
+
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, device_id)},
+            manufacturer="Jackery",
+            model=(
+                device.get("devModel")
+                or device.get("productType")
+                or device.get("modelName")
+                or device_name
+            ),
+            name=device_name,
+            serial_number=device.get("devSn"),
+        )
 
         async def _async_update_data(api_client=api, dev_id=device_id):
             """Fetch data from API endpoint."""
@@ -81,13 +106,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
         await coordinator.async_config_entry_first_refresh()
         coordinators[device_id] = coordinator
+        expected_ids.update(expected_unique_ids(device_id, coordinator.data))
 
     hass.data[DOMAIN][entry.entry_id] = {
         "coordinators": coordinators,
         "devices": devices,
+        "api": api,
     }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    _cleanup_stale_entities(hass, entry, expected_ids)
 
     return True
 
@@ -98,3 +126,23 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+def _cleanup_stale_entities(
+    hass: HomeAssistant, entry: ConfigEntry, expected_ids: set[str]
+) -> None:
+    """Remove entities that no longer match the current device capabilities."""
+    entity_registry = er.async_get(hass)
+    entries = list(er.async_entries_for_config_entry(entity_registry, entry.entry_id))
+    for entity_entry in entries:
+        if entity_entry.platform != DOMAIN:
+            continue
+        if entity_entry.unique_id not in expected_ids:
+            entity_registry.async_remove(entity_entry.entity_id)
+            continue
+
+        _, _, property_key = entity_entry.unique_id.partition("_")
+        expected_domain = expected_entity_domain_for_key(property_key)
+        actual_domain, _, _ = entity_entry.entity_id.partition(".")
+        if expected_domain is not None and actual_domain != expected_domain:
+            entity_registry.async_remove(entity_entry.entity_id)

--- a/custom_components/jackery/api.py
+++ b/custom_components/jackery/api.py
@@ -1,5 +1,6 @@
 """API client for Jackery cloud services."""
 
+import asyncio
 import base64
 import hashlib
 import json
@@ -34,6 +35,7 @@ class JackeryAPI:
         self._token_expiry_time: float = (
             0  # We will assume a long expiry for simplicity
         )
+        self._command_lock = asyncio.Lock()
 
     def _name_uuid_from_bytes_java(self, data: bytes) -> str:
         """Generate a version 3 UUID using an MD5 hash."""
@@ -195,3 +197,22 @@ class JackeryAPI:
     def get_device_detail(self, device_id: str) -> dict:
         """Get detailed information for a specified device."""
         return self._get_request("/v1/device/property", params={"deviceId": device_id})
+
+    async def async_set_property(
+        self, device_id: str, property_key: str, value: str | int
+    ) -> dict | None:
+        """Set a device property via Jackery's MQTT control channel."""
+        from socketry import Client
+
+        async with self._command_lock:
+            client = await Client.login(self.account, self.password)
+            devices = await client.fetch_devices()
+            target = next(
+                (device for device in devices if str(device.get("devId")) == str(device_id)),
+                None,
+            )
+            if target is None:
+                raise ValueError(f"Jackery device {device_id} was not found for this account.")
+
+            device = client.device(str(target["devSn"]))
+            return await device.set_property(property_key, value, wait=True)

--- a/custom_components/jackery/binary_sensor.py
+++ b/custom_components/jackery/binary_sensor.py
@@ -16,6 +16,8 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .const import DOMAIN, BINARY_SENSOR_DESCRIPTIONS
+from .entity_helpers import JackeryCoordinatorEntity
+from .features import supported_keys_for_platform
 
 
 async def async_setup_entry(
@@ -33,14 +35,18 @@ async def async_setup_entry(
         device_id = device["devId"]
         if device_id in coordinators:
             coordinator = coordinators[device_id]
-            # Create entities for all binary sensor descriptions
+            supported_keys = set(
+                supported_keys_for_platform(coordinator.data, "binary_sensor")
+            )
             for description in BINARY_SENSOR_DESCRIPTIONS:
+                if description.key not in supported_keys:
+                    continue
                 entities.append(JackeryBinarySensor(coordinator, description, device))
 
     async_add_entities(entities)
 
 
-class JackeryBinarySensor(CoordinatorEntity, BinarySensorEntity):
+class JackeryBinarySensor(JackeryCoordinatorEntity, BinarySensorEntity):
     """Implementation of a Jackery binary sensor."""
 
     entity_description: BinarySensorEntityDescription
@@ -52,32 +58,13 @@ class JackeryBinarySensor(CoordinatorEntity, BinarySensorEntity):
         device_info: dict,
     ) -> None:
         """Initialize the binary sensor."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, description.key, device_info)
         self.entity_description = description
-        self._device_id = device_info["devId"]
-
-        # Set a unique ID for this entity
-        self._attr_unique_id = f"{self._device_id}_{description.key}"
-
-        # Set the device info for this entity
-        # This groups all sensors under a single device in Home Assistant
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, self._device_id)},
-            "name": device_info.get("devName", f"Jackery Device {self._device_id}"),
-            "manufacturer": "Jackery",
-            "model": device_info.get("productType"),
-        }
 
     @property
     def is_on(self) -> bool | None:
-        """Return true if the binary sensor is on.
-        
-        Different Jackery models emit different DC output parameters:
-        - odc: DC Output (models with combined USB + Car toggle)
-        - odcc: DC Car Output (models with separate toggles)
-        - odcu: USB Output (models with separate toggles)
-        """
-        value = self.coordinator.data.get(self.entity_description.key)
+        """Return true if the binary sensor is on."""
+        value = self.property_value
         if value is None:
             return None
         return value == 1

--- a/custom_components/jackery/const.py
+++ b/custom_components/jackery/const.py
@@ -7,13 +7,17 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntityDescription,
 )
+from homeassistant.components.number import NumberEntityDescription
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntityDescription,
     SensorStateClass,
 )
+from homeassistant.components.select import SelectEntityDescription
+from homeassistant.components.switch import SwitchDeviceClass, SwitchEntityDescription
 from homeassistant.const import (
     PERCENTAGE,
+    EntityCategory,
     UnitOfElectricPotential,
     UnitOfPower,
     UnitOfTemperature,
@@ -34,8 +38,16 @@ class JackerySensorEntityDescription(SensorEntityDescription):
     value: Callable[[any], any] | None = None
 
 
+@dataclass
+class JackerySelectEntityDescription(SelectEntityDescription):
+    """Describes a Jackery select entity."""
+
+
+# Shared configuration entity ranges.
+SETTING_MAX_VALUE = 999
+
+
 # Sensor descriptions
-# This defines all the sensors we'll create for each device.
 SENSOR_DESCRIPTIONS: tuple[JackerySensorEntityDescription, ...] = (
     JackerySensorEntityDescription(
         key="rb",
@@ -74,6 +86,13 @@ SENSOR_DESCRIPTIONS: tuple[JackerySensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
     ),
     JackerySensorEntityDescription(
+        key="cip",
+        name="Car Input Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    JackerySensorEntityDescription(
         key="it",
         name="Time to Full",
         native_unit_of_measurement=UnitOfTime.HOURS,
@@ -98,42 +117,156 @@ SENSOR_DESCRIPTIONS: tuple[JackerySensorEntityDescription, ...] = (
         value=lambda value: value / 10.0,
     ),
     JackerySensorEntityDescription(
+        key="acohz",
+        name="AC Output Frequency",
+        native_unit_of_measurement="Hz",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:sine-wave",
+    ),
+    JackerySensorEntityDescription(
+        key="ec",
+        name="Error Code",
+        icon="mdi:alert-circle-outline",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    JackerySensorEntityDescription(
         key="last_updated",
         name="Last Updated",
         device_class=SensorDeviceClass.TIMESTAMP,
         icon="mdi:clock",
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )
 
 # Binary sensor descriptions
-# These define all binary (ON/OFF) sensors for each device.
-# Note: Different device models may emit different parameters:
-# - odc: DC Output (for models with single DC toggle for USB + Car)
-# - odcc: DC Car Output (for models with separate DC Car toggle)
-# - odcu: USB Output (for models with separate USB toggle)
 BINARY_SENSOR_DESCRIPTIONS: tuple[BinarySensorEntityDescription, ...] = (
     BinarySensorEntityDescription(
+        key="ta",
+        name="Temperature Alarm",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:thermometer-alert",
+    ),
+    BinarySensorEntityDescription(
+        key="pal",
+        name="Power Alarm",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:alert",
+    ),
+    BinarySensorEntityDescription(
+        key="wss",
+        name="Wireless Charging",
+        device_class=BinarySensorDeviceClass.POWER,
+        icon="mdi:charging-wireless",
+    ),
+)
+
+SWITCH_DESCRIPTIONS: tuple[SwitchEntityDescription, ...] = (
+    SwitchEntityDescription(
         key="oac",
         name="AC Output",
-        device_class=BinarySensorDeviceClass.POWER,
+        device_class=SwitchDeviceClass.SWITCH,
         icon="mdi:power-plug",
     ),
-    BinarySensorEntityDescription(
+    SwitchEntityDescription(
         key="odc",
         name="DC Output",
-        device_class=BinarySensorDeviceClass.POWER,
+        device_class=SwitchDeviceClass.SWITCH,
         icon="mdi:power",
     ),
-    BinarySensorEntityDescription(
-        key="odcc",
-        name="DC Car Output",
-        device_class=BinarySensorDeviceClass.POWER,
-        icon="mdi:car",
-    ),
-    BinarySensorEntityDescription(
+    SwitchEntityDescription(
         key="odcu",
         name="USB Output",
-        device_class=BinarySensorDeviceClass.POWER,
+        device_class=SwitchDeviceClass.SWITCH,
         icon="mdi:usb-port",
+    ),
+    SwitchEntityDescription(
+        key="odcc",
+        name="DC Car Output",
+        device_class=SwitchDeviceClass.SWITCH,
+        icon="mdi:car",
+    ),
+    SwitchEntityDescription(
+        key="iac",
+        name="AC Input",
+        device_class=SwitchDeviceClass.SWITCH,
+        icon="mdi:transmission-tower-import",
+    ),
+    SwitchEntityDescription(
+        key="idc",
+        name="DC Input",
+        device_class=SwitchDeviceClass.SWITCH,
+        icon="mdi:current-dc",
+    ),
+    SwitchEntityDescription(
+        key="sfc",
+        name="Super Fast Charge",
+        device_class=SwitchDeviceClass.SWITCH,
+        icon="mdi:lightning-bolt",
+        entity_category=EntityCategory.CONFIG,
+    ),
+    SwitchEntityDescription(
+        key="ups",
+        name="UPS Mode",
+        device_class=SwitchDeviceClass.SWITCH,
+        icon="mdi:power-plug-battery",
+        entity_category=EntityCategory.CONFIG,
+    ),
+)
+
+SELECT_DESCRIPTIONS: tuple[JackerySelectEntityDescription, ...] = (
+    JackerySelectEntityDescription(
+        key="lm",
+        name="Light Mode",
+        options=["off", "low", "high", "sos"],
+        icon="mdi:lightbulb",
+    ),
+    JackerySelectEntityDescription(
+        key="cs",
+        name="Charge Speed",
+        options=["fast", "mute"],
+        icon="mdi:speedometer",
+        entity_category=EntityCategory.CONFIG,
+    ),
+    JackerySelectEntityDescription(
+        key="lps",
+        name="Battery Protection",
+        options=["full", "eco"],
+        icon="mdi:battery-heart-variant",
+        entity_category=EntityCategory.CONFIG,
+    ),
+)
+
+NUMBER_DESCRIPTIONS: tuple[NumberEntityDescription, ...] = (
+    NumberEntityDescription(
+        key="ast",
+        name="Auto Shutdown",
+        icon="mdi:timer-off-outline",
+        mode="box",
+        native_min_value=0,
+        native_max_value=SETTING_MAX_VALUE,
+        native_step=1,
+        entity_category=EntityCategory.CONFIG,
+    ),
+    NumberEntityDescription(
+        key="pm",
+        name="Energy Saving",
+        icon="mdi:leaf",
+        mode="box",
+        native_min_value=0,
+        native_max_value=SETTING_MAX_VALUE,
+        native_step=1,
+        entity_category=EntityCategory.CONFIG,
+    ),
+    NumberEntityDescription(
+        key="sltb",
+        name="Screen Timeout",
+        icon="mdi:monitor-lock",
+        mode="box",
+        native_min_value=0,
+        native_max_value=SETTING_MAX_VALUE,
+        native_step=1,
+        entity_category=EntityCategory.CONFIG,
     ),
 )

--- a/custom_components/jackery/entity_helpers.py
+++ b/custom_components/jackery/entity_helpers.py
@@ -1,0 +1,96 @@
+"""Shared entity helpers for Jackery platforms."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN
+
+
+def build_device_info(device: Mapping[str, Any]) -> DeviceInfo:
+    """Build Home Assistant device metadata."""
+    model = (
+        device.get("devModel")
+        or device.get("productType")
+        or device.get("modelName")
+        or device.get("devName")
+    )
+    return DeviceInfo(
+        identifiers={(DOMAIN, device["devId"])},
+        name=device.get("devName", f"Jackery Device {device['devId']}"),
+        manufacturer="Jackery",
+        model=model,
+        serial_number=device.get("devSn"),
+    )
+
+
+class JackeryCoordinatorEntity(CoordinatorEntity):
+    """Base coordinator-backed Jackery entity."""
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        property_key: str,
+        device: Mapping[str, Any],
+    ) -> None:
+        """Initialize the shared entity state."""
+        super().__init__(coordinator)
+        self._device = dict(device)
+        self._device_id = str(device["devId"])
+        self._property_key = property_key
+        self._attr_unique_id = f"{self._device_id}_{property_key}"
+        self._attr_device_info = build_device_info(device)
+
+    @property
+    def property_value(self) -> Any:
+        """Return the current raw property value."""
+        return self.coordinator.data.get(self._property_key)
+
+
+class JackeryControllableEntity(JackeryCoordinatorEntity):
+    """Base class for MQTT-backed Jackery control entities."""
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        api: Any,
+        property_key: str,
+        device: Mapping[str, Any],
+    ) -> None:
+        """Initialize the controllable entity."""
+        super().__init__(coordinator, property_key, device)
+        self._api = api
+
+    async def async_set_jackery_value(self, value: str | int) -> None:
+        """Push a value to Jackery and refresh coordinator state."""
+        try:
+            result = await self._api.async_set_property(
+                self._device_id,
+                self._property_key,
+                value,
+            )
+        except Exception as err:  # pragma: no cover - exercised in HA runtime
+            raise HomeAssistantError(str(err)) from err
+
+        if isinstance(result, dict) and result:
+            updated = dict(self.coordinator.data)
+            updated.update(result)
+            updated["last_updated"] = dt_util.now()
+            self.coordinator.async_set_updated_data(updated)
+
+        await self.coordinator.async_request_refresh()
+
+    @callback
+    def update_coordinator_state(self, values: Mapping[str, Any]) -> None:
+        """Apply device-reported values to the coordinator immediately."""
+        updated = dict(self.coordinator.data)
+        updated.update(values)
+        updated["last_updated"] = dt_util.now()
+        self.coordinator.async_set_updated_data(updated)

--- a/custom_components/jackery/features.py
+++ b/custom_components/jackery/features.py
@@ -1,0 +1,109 @@
+"""Property capability metadata for Jackery devices."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+SENSOR_KEYS: tuple[str, ...] = (
+    "rb",
+    "bt",
+    "op",
+    "ip",
+    "acip",
+    "cip",
+    "it",
+    "ot",
+    "acov",
+    "acohz",
+    "ec",
+    "last_updated",
+)
+
+BINARY_SENSOR_KEYS: tuple[str, ...] = (
+    "ta",
+    "pal",
+    "wss",
+)
+
+SWITCH_KEYS: tuple[str, ...] = (
+    "oac",
+    "odc",
+    "odcu",
+    "odcc",
+    "iac",
+    "idc",
+    "sfc",
+    "ups",
+)
+
+SELECT_KEYS: tuple[str, ...] = (
+    "lm",
+    "cs",
+    "lps",
+)
+
+NUMBER_KEYS: tuple[str, ...] = (
+    "ast",
+    "pm",
+    "sltb",
+)
+
+PLATFORM_KEYS: dict[str, tuple[str, ...]] = {
+    "sensor": SENSOR_KEYS,
+    "binary_sensor": BINARY_SENSOR_KEYS,
+    "switch": SWITCH_KEYS,
+    "select": SELECT_KEYS,
+    "number": NUMBER_KEYS,
+}
+
+ENTITY_DOMAIN_BY_KEY: dict[str, str] = {
+    key: platform for platform, keys in PLATFORM_KEYS.items() for key in keys
+}
+
+SELECT_OPTIONS: dict[str, tuple[str, ...]] = {
+    "lm": ("off", "low", "high", "sos"),
+    "cs": ("fast", "mute"),
+    "lps": ("full", "eco"),
+}
+
+WRITE_KEY_OVERRIDES: dict[str, str] = {
+    "sltb": "slt",
+}
+
+LEGACY_OUTPUT_KEYS: tuple[str, ...] = (
+    "oac",
+    "odc",
+    "odcu",
+    "odcc",
+)
+
+
+def supported_keys_for_platform(
+    properties: Mapping[str, object], platform: str
+) -> tuple[str, ...]:
+    """Return the supported property keys for a platform."""
+    return tuple(key for key in PLATFORM_KEYS[platform] if key in properties)
+
+
+def supported_keys_by_platform(
+    properties: Mapping[str, object],
+) -> dict[str, tuple[str, ...]]:
+    """Return supported property keys for every platform."""
+    return {
+        platform: supported_keys_for_platform(properties, platform)
+        for platform in PLATFORM_KEYS
+    }
+
+
+def expected_unique_ids(device_id: str | int, properties: Mapping[str, object]) -> set[str]:
+    """Return the set of entity unique IDs expected for a device."""
+    return {
+        f"{device_id}_{key}"
+        for keys in supported_keys_by_platform(properties).values()
+        for key in keys
+    }
+
+
+def expected_entity_domain_for_key(key: str) -> str | None:
+    """Return the Home Assistant entity domain expected for a property key."""
+    return ENTITY_DOMAIN_BY_KEY.get(key)

--- a/custom_components/jackery/manifest.json
+++ b/custom_components/jackery/manifest.json
@@ -1,12 +1,13 @@
 {
     "domain": "jackery",
     "name": "Jackery",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "documentation": "https://github.com/theak/jackery-homeassistant/blob/main/README.md",
     "issue_tracker": "https://github.com/theak/jackery-homeassistant/issues",
     "codeowners": ["@theak"],
     "requirements": ["requests>=2.31.0", "pycryptodomex>=3.19.0"],
     "icon": "icon.png",
+    "homeassistant": "2023.8.0",
     "iot_class": "cloud_polling",
     "config_flow": true
 }

--- a/custom_components/jackery/manifest.json
+++ b/custom_components/jackery/manifest.json
@@ -1,11 +1,11 @@
 {
     "domain": "jackery",
     "name": "Jackery",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "documentation": "https://github.com/theak/jackery-homeassistant/blob/main/README.md",
     "issue_tracker": "https://github.com/theak/jackery-homeassistant/issues",
     "codeowners": ["@theak"],
-    "requirements": ["requests>=2.31.0", "pycryptodomex>=3.19.0"],
+    "requirements": ["requests>=2.31.0", "pycryptodomex>=3.19.0", "socketry>=0.2.3"],
     "icon": "icon.png",
     "homeassistant": "2023.8.0",
     "iot_class": "cloud_polling",

--- a/custom_components/jackery/number.py
+++ b/custom_components/jackery/number.py
@@ -1,0 +1,68 @@
+"""Number platform for Jackery."""
+
+from __future__ import annotations
+
+from homeassistant.components.number import NumberEntity, NumberEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN, NUMBER_DESCRIPTIONS
+from .entity_helpers import JackeryControllableEntity
+from .features import supported_keys_for_platform
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Jackery numbers."""
+    entry_data = hass.data[DOMAIN][config_entry.entry_id]
+    coordinators: dict[str, DataUpdateCoordinator] = entry_data["coordinators"]
+    devices: list[dict] = entry_data["devices"]
+    api = entry_data["api"]
+
+    entities = []
+    for device in devices:
+        device_id = device["devId"]
+        if device_id not in coordinators:
+            continue
+        coordinator = coordinators[device_id]
+        supported_keys = set(supported_keys_for_platform(coordinator.data, "number"))
+        for description in NUMBER_DESCRIPTIONS:
+            if description.key not in supported_keys:
+                continue
+            entities.append(JackeryNumber(coordinator, api, description, device))
+
+    async_add_entities(entities)
+
+
+class JackeryNumber(JackeryControllableEntity, NumberEntity):
+    """A Jackery number entity."""
+
+    entity_description: NumberEntityDescription
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        api,
+        description: NumberEntityDescription,
+        device: dict,
+    ) -> None:
+        """Initialize the number entity."""
+        super().__init__(coordinator, api, description.key, device)
+        self.entity_description = description
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current numeric value."""
+        value = self.property_value
+        if value is None:
+            return None
+        return float(value)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set a numeric Jackery property."""
+        await self.async_set_jackery_value(int(value))

--- a/custom_components/jackery/select.py
+++ b/custom_components/jackery/select.py
@@ -1,0 +1,71 @@
+"""Select platform for Jackery."""
+
+from __future__ import annotations
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN, JackerySelectEntityDescription, SELECT_DESCRIPTIONS
+from .entity_helpers import JackeryControllableEntity
+from .features import supported_keys_for_platform
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Jackery selects."""
+    entry_data = hass.data[DOMAIN][config_entry.entry_id]
+    coordinators: dict[str, DataUpdateCoordinator] = entry_data["coordinators"]
+    devices: list[dict] = entry_data["devices"]
+    api = entry_data["api"]
+
+    entities = []
+    for device in devices:
+        device_id = device["devId"]
+        if device_id not in coordinators:
+            continue
+        coordinator = coordinators[device_id]
+        supported_keys = set(supported_keys_for_platform(coordinator.data, "select"))
+        for description in SELECT_DESCRIPTIONS:
+            if description.key not in supported_keys:
+                continue
+            entities.append(JackerySelect(coordinator, api, description, device))
+
+    async_add_entities(entities)
+
+
+class JackerySelect(JackeryControllableEntity, SelectEntity):
+    """A Jackery select entity."""
+
+    entity_description: JackerySelectEntityDescription
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        api,
+        description: JackerySelectEntityDescription,
+        device: dict,
+    ) -> None:
+        """Initialize the select."""
+        super().__init__(coordinator, api, description.key, device)
+        self.entity_description = description
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the currently selected option."""
+        value = self.property_value
+        if value is None:
+            return None
+        try:
+            return self.entity_description.options[int(value)]
+        except (IndexError, TypeError, ValueError):
+            return None
+
+    async def async_select_option(self, option: str) -> None:
+        """Select a Jackery option."""
+        await self.async_set_jackery_value(option)

--- a/custom_components/jackery/sensor.py
+++ b/custom_components/jackery/sensor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+
 from homeassistant.components.sensor import (
     SensorEntity,
 )
@@ -15,6 +16,8 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .const import DOMAIN, SENSOR_DESCRIPTIONS, JackerySensorEntityDescription
+from .entity_helpers import JackeryCoordinatorEntity
+from .features import supported_keys_for_platform
 
 
 async def async_setup_entry(
@@ -32,14 +35,16 @@ async def async_setup_entry(
         device_id = device["devId"]
         if device_id in coordinators:
             coordinator = coordinators[device_id]
-            # Create entities for all sensor descriptions
+            supported_keys = set(supported_keys_for_platform(coordinator.data, "sensor"))
             for description in SENSOR_DESCRIPTIONS:
+                if description.key not in supported_keys:
+                    continue
                 entities.append(JackerySensor(coordinator, description, device))
 
     async_add_entities(entities)
 
 
-class JackerySensor(CoordinatorEntity, SensorEntity):
+class JackerySensor(JackeryCoordinatorEntity, SensorEntity):
     """Implementation of a Jackery sensor."""
 
     entity_description: JackerySensorEntityDescription
@@ -51,26 +56,13 @@ class JackerySensor(CoordinatorEntity, SensorEntity):
         device_info: dict,
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, description.key, device_info)
         self.entity_description = description
-        self._device_id = device_info["devId"]
-
-        # Set a unique ID for this entity
-        self._attr_unique_id = f"{self._device_id}_{description.key}"
-
-        # Set the device info for this entity
-        # This groups all sensors under a single device in Home Assistant
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, self._device_id)},
-            "name": device_info.get("devName", f"Jackery Device {self._device_id}"),
-            "manufacturer": "Jackery",
-            "model": device_info.get("productType"),
-        }
 
     @property
     def native_value(self) -> str | int | float | datetime | None:
         """Return the state of the sensor."""
-        value = self.coordinator.data.get(self.entity_description.key)
+        value = self.property_value
         if value is None:
             return None
         if self.entity_description.value:

--- a/custom_components/jackery/switch.py
+++ b/custom_components/jackery/switch.py
@@ -1,0 +1,72 @@
+"""Switch platform for Jackery."""
+
+from __future__ import annotations
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN, SWITCH_DESCRIPTIONS
+from .entity_helpers import JackeryControllableEntity
+from .features import supported_keys_for_platform
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Jackery switches."""
+    entry_data = hass.data[DOMAIN][config_entry.entry_id]
+    coordinators: dict[str, DataUpdateCoordinator] = entry_data["coordinators"]
+    devices: list[dict] = entry_data["devices"]
+    api = entry_data["api"]
+
+    entities = []
+    for device in devices:
+        device_id = device["devId"]
+        if device_id not in coordinators:
+            continue
+        coordinator = coordinators[device_id]
+        supported_keys = set(supported_keys_for_platform(coordinator.data, "switch"))
+        for description in SWITCH_DESCRIPTIONS:
+            if description.key not in supported_keys:
+                continue
+            entities.append(JackerySwitch(coordinator, api, description, device))
+
+    async_add_entities(entities)
+
+
+class JackerySwitch(JackeryControllableEntity, SwitchEntity):
+    """A Jackery switch entity."""
+
+    entity_description: SwitchEntityDescription
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        api,
+        description: SwitchEntityDescription,
+        device: dict,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator, api, description.key, device)
+        self.entity_description = description
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the current switch state."""
+        value = self.property_value
+        if value is None:
+            return None
+        return value == 1
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Turn the switch on."""
+        await self.async_set_jackery_value("on")
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Turn the switch off."""
+        await self.async_set_jackery_value("off")

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,5 @@
 {
   "name": "Jackery",
+  "homeassistant": "2023.8.0",
   "render_readme": true
 }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,103 @@
+"""Tests for Jackery capability gating."""
+
+from __future__ import annotations
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+
+FEATURES_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "jackery"
+    / "features.py"
+)
+spec = spec_from_file_location("jackery_features", FEATURES_PATH)
+features = module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(features)
+
+expected_unique_ids = features.expected_unique_ids
+expected_entity_domain_for_key = features.expected_entity_domain_for_key
+supported_keys_by_platform = features.supported_keys_by_platform
+
+
+EXPLORER_240_PROPERTIES = {
+    "lm": 0,
+    "ast": 0,
+    "pmb": 0,
+    "cip": 0,
+    "oac": 1,
+    "bs": 0,
+    "bt": 320,
+    "pal": 0,
+    "acohz": 50,
+    "ec": 0,
+    "op": 10,
+    "acip": 72,
+    "acov": 2491,
+    "ot": 999,
+    "ip": 72,
+    "it": 1,
+    "acpss": 0,
+    "ta": 0,
+    "lps": 0,
+    "acpsp": 0,
+    "odc": 1,
+    "rb": 99,
+    "cs": 0,
+    "sfc": 0,
+    "sltb": 3,
+    "pm": 0,
+    "last_updated": "2026-03-26T01:00:00+00:00",
+}
+
+
+def test_explorer_240_only_exposes_supported_entities() -> None:
+    platforms = supported_keys_by_platform(EXPLORER_240_PROPERTIES)
+
+    assert platforms["switch"] == ("oac", "odc", "sfc")
+    assert platforms["select"] == ("lm", "cs", "lps")
+    assert platforms["number"] == ("ast", "pm", "sltb")
+    assert "odcu" not in platforms["switch"]
+    assert "odcc" not in platforms["switch"]
+    assert "wss" not in platforms["binary_sensor"]
+
+
+def test_devices_with_separate_outputs_get_their_own_controls() -> None:
+    properties = {
+        "oac": 1,
+        "odcu": 1,
+        "odcc": 0,
+        "odc": 1,
+        "iac": 0,
+        "idc": 1,
+        "ups": 0,
+        "wss": 1,
+        "lm": 2,
+        "last_updated": "2026-03-26T01:00:00+00:00",
+    }
+
+    platforms = supported_keys_by_platform(properties)
+
+    assert platforms["switch"] == ("oac", "odc", "odcu", "odcc", "iac", "idc", "ups")
+    assert platforms["binary_sensor"] == ("wss",)
+
+
+def test_expected_unique_ids_match_supported_capabilities() -> None:
+    unique_ids = expected_unique_ids("474359726516207616", EXPLORER_240_PROPERTIES)
+
+    assert "474359726516207616_oac" in unique_ids
+    assert "474359726516207616_odc" in unique_ids
+    assert "474359726516207616_sfc" in unique_ids
+    assert "474359726516207616_odcu" not in unique_ids
+    assert "474359726516207616_odcc" not in unique_ids
+
+
+def test_expected_entity_domain_tracks_platform_migrations() -> None:
+    assert expected_entity_domain_for_key("oac") == "switch"
+    assert expected_entity_domain_for_key("odc") == "switch"
+    assert expected_entity_domain_for_key("ta") == "binary_sensor"
+    assert expected_entity_domain_for_key("lm") == "select"
+    assert expected_entity_domain_for_key("ast") == "number"
+    assert expected_entity_domain_for_key("unknown") is None

--- a/tests/test_hacs_metadata.py
+++ b/tests/test_hacs_metadata.py
@@ -32,5 +32,5 @@ def test_hacs_manifest_declares_supported_home_assistant_version() -> None:
 def test_manifest_version_is_bumped_past_broken_release() -> None:
     manifest = _load_json(INTEGRATION_MANIFEST)
 
-    assert manifest["version"] == "1.0.2"
+    assert manifest["version"] == "1.1.0"
     assert manifest["homeassistant"] == "2023.8.0"

--- a/tests/test_hacs_metadata.py
+++ b/tests/test_hacs_metadata.py
@@ -1,0 +1,36 @@
+"""Regression tests for HACS packaging metadata."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HACS_MANIFEST = REPO_ROOT / "hacs.json"
+INTEGRATION_HACS_MANIFEST = REPO_ROOT / "custom_components" / "jackery" / "hacs.json"
+INTEGRATION_MANIFEST = REPO_ROOT / "custom_components" / "jackery" / "manifest.json"
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def test_hacs_manifest_exists_at_repository_root() -> None:
+    assert HACS_MANIFEST.is_file()
+    assert not INTEGRATION_HACS_MANIFEST.exists()
+
+
+def test_hacs_manifest_declares_supported_home_assistant_version() -> None:
+    hacs_manifest = _load_json(HACS_MANIFEST)
+
+    assert hacs_manifest["name"] == "Jackery"
+    assert hacs_manifest["homeassistant"] == "2023.8.0"
+
+
+def test_manifest_version_is_bumped_past_broken_release() -> None:
+    manifest = _load_json(INTEGRATION_MANIFEST)
+
+    assert manifest["version"] == "1.0.2"
+    assert manifest["homeassistant"] == "2023.8.0"


### PR DESCRIPTION
## Summary

This PR fixes the HACS release metadata issue that breaks installation from version `1.0.1`, and it expands the integration to expose model-aware Jackery controls and settings in Home Assistant.

## Root cause of the HACS failure

The `1.0.1` release was tagged before `hacs.json` was moved to the repository root.

Newer HACS versions validate a release using the root-level `hacs.json`. The `1.0.1` tag does not contain that file at the repository root, so HACS rejects the release even though `main` already has the correct layout.

## What changed

- bump the integration version to `1.1.0`
- keep HACS metadata aligned with newer HACS requirements
- add model-aware entity gating so devices only get entities for properties they actually report
- add MQTT-backed `switch`, `select`, and `number` platforms for supported Jackery controls
- keep unsupported controls hidden on models that do not expose those features
- move output controls from the old binary-sensor approach to proper switch entities
- fix device metadata to use `devModel` so the Home Assistant device model is populated correctly
- add stale-entity cleanup for capability changes during upgrades
- update the README for the new control entities and model-aware behavior
- add regression tests for HACS metadata and capability gating

## Examples of the new entity model

Depending on the Jackery model, the integration can now expose:

- `switch.ac_output`
- `switch.dc_output`
- `switch.usb_output`
- `switch.dc_car_output`
- `switch.super_fast_charge`
- `select.light_mode`
- `select.charge_speed`
- `select.battery_protection`
- `number.auto_shutdown`
- `number.energy_saving`
- `number.screen_timeout`

If a device only reports combined DC output, separate USB and car entities are not created.

## How to test this PR in HACS

This PR can be tested before merge by adding my fork as a custom repository in HACS:

Repository:
- `https://github.com/usersaynoso/jackery-homeassistant`

Steps:
1. Open HACS in Home Assistant.
2. Go to the menu in the top-right and choose `Custom repositories`.
3. Add `https://github.com/usersaynoso/jackery-homeassistant`.
4. Select category `Integration`.
5. Click `Add`.
6. Search for `Jackery` in HACS.
7. Open the repository and use `Download`.
8. Choose the PR branch or the latest version from this fork if HACS prompts for a version.
9. Restart Home Assistant.
10. Add or reload the Jackery integration from `Settings` -> `Devices & Services`.

If HACS has the upstream repo cached already, removing the existing custom repository entry first can make it clearer that Home Assistant is installing from the fork.

## Verification

- `.venv/bin/pytest -q`
- `.venv/bin/python -m compileall custom_components tests`

This should make the next published release installable in HACS again while also exposing the newer Jackery control surface in a Home Assistant-native way.
