### PR TITLE
[codex] Automate HACS release publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing semantic version tag to publish or verify
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip non-semver tags
+        id: semver
+        env:
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          if [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub release
+        if: steps.semver.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          if gh release view "$TAG" --repo "$REPOSITORY" >/dev/null 2>&1; then
+            exit 0
+          fi
+          gh release create "$TAG" --repo "$REPOSITORY" --title "$TAG" --generate-notes

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Custom Home Assistant integration for monitoring Jackery portable power stations
 3. Search for "Jackery" in the integrations section
 4. Click "Download" and restart Home Assistant
 
+HACS installs published version tags from GitHub releases. This repository publishes a matching GitHub release automatically whenever a semantic version tag is pushed.
+
 ### Option 2: Manual Installation
 
 1. Download or clone this repository
@@ -151,6 +153,8 @@ logger:
 ## Contributing
 
 Pull Requests are encouraged and welcome! For major changes, please open an issue first to discuss what you would like to change.
+
+When changing `custom_components/jackery/manifest.json` version metadata, push the matching semantic version tag so HACS can install that version directly.
 
 ## License
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,52 @@
+"""Regression tests for repository metadata used by HACS."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = REPO_ROOT / "custom_components" / "jackery" / "manifest.json"
+README_PATH = REPO_ROOT / "README.md"
+
+
+class MetadataTests(unittest.TestCase):
+    """Validate upstream versioning and canonical repository links."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.manifest = json.loads(MANIFEST_PATH.read_text())
+        cls.readme = README_PATH.read_text()
+
+    def test_manifest_points_to_canonical_repository(self) -> None:
+        """Manifest links should resolve to the canonical upstream repository."""
+        self.assertEqual(
+            self.manifest["documentation"],
+            "https://github.com/theak/jackery-homeassistant/blob/main/README.md",
+        )
+        self.assertEqual(
+            self.manifest["issue_tracker"],
+            "https://github.com/theak/jackery-homeassistant/issues",
+        )
+        self.assertEqual(self.manifest["codeowners"], ["@theak"])
+
+    def test_readme_version_badge_matches_manifest(self) -> None:
+        """README badge should advertise the same release as the manifest."""
+        version = self.manifest["version"]
+        self.assertIn(
+            f"https://img.shields.io/badge/version-{version}-blue.svg",
+            self.readme,
+        )
+
+    def test_repository_files_do_not_reference_fork_metadata(self) -> None:
+        """Published docs should not drift to a fork-specific repository."""
+        fork_repo = "usersaynoso/jackery-homeassistant"
+        checked_files = [MANIFEST_PATH, README_PATH]
+        for file_path in checked_files:
+            self.assertNotIn(fork_repo, file_path.read_text(), str(file_path))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a tag-driven GitHub release workflow, with manual dispatch support for publishing an existing semantic version tag
- add metadata regression tests that keep the manifest and README aligned and prevent fork-specific links from leaking into the canonical repo
- document the release/tag expectation in the README so future version bumps stay HACS-compatible

## Why
HACS installability depends on the manifest version resolving to a usable GitHub release. This repository already publishes releases manually, but that process is easy to miss during future version bumps.

## Impact
- no integration runtime behavior changes
- future semantic version tags automatically create or verify the matching GitHub release
- maintainers can manually dispatch the release workflow for an existing tag if a release needs to be recreated

## Root Cause
Release publishing is currently manual, while HACS expects version metadata and downloadable release refs to stay in sync.

## Validation
- python3 -m unittest discover -s tests -v
- python3 -m compileall custom_components
